### PR TITLE
[hermes-agent] ci: add explicit GHCR package write permission

### DIFF
--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -12,6 +12,10 @@ on:
       - main
       - track/*
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[hermes-agent]

## Summary
- Add explicit workflow-level permissions to the release workflow.
- Grant `packages: write` so `GITHUB_TOKEN` can push `ghcr.io/canonical/ros2bag-fileserver`.
- Keep `contents: read` as least-privilege baseline.

## Why
The failing run shows the push step denied while uploading to GHCR:
- `denied: installation not allowed to Write organization package`

This matches GitHub Actions' explicit permission model when workflow permissions are restricted by default.

## Test plan
- [x] Trigger `rock-release-dev.yaml` on this branch and verify `Upload ROCK to ghcr.io` succeeds.
